### PR TITLE
Map Double Use

### DIFF
--- a/examples/chicken.rs
+++ b/examples/chicken.rs
@@ -54,7 +54,6 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
     gfx.set_background_palette(&MAP_PALETTE);
     gfx.set_background_tilemap(&MAP_TILES);
 
-    gfx.background_0.enable();
     gfx.background_0
         .set_background_size(tiled0::BackgroundSize::S32x32);
     gfx.background_0
@@ -62,8 +61,10 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
     // This interface is not yet safe, as this can easily clobber the tiles.
     // Not sure how to make this interface safe to use
-    gfx.background_0.set_screen_base_block(1);
+    gfx.background_0.set_map(1);
     gfx.copy_to_map(1, &MAP_MAP);
+
+    gfx.background_0.enable();
 
     let mut object = gfx.object;
 

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -57,7 +57,7 @@ pub struct Display {
 impl Display {
     pub(crate) const unsafe fn new() -> Self {
         Display {
-            video: Video {},
+            video: Video::new(),
             vblank: VBlankGiver {},
         }
     }

--- a/src/display/video.rs
+++ b/src/display/video.rs
@@ -1,9 +1,19 @@
+use core::cell::Cell;
+
 use super::{bitmap3::Bitmap3, bitmap4::Bitmap4, tiled0::Tiled0};
 
 #[non_exhaustive]
-pub struct Video {}
+pub struct Video {
+    blocks: Cell<u32>,
+}
 
 impl Video {
+    pub(crate) const unsafe fn new() -> Video {
+        Video {
+            blocks: Cell::new(!0),
+        }
+    }
+
     /// Bitmap mode that provides a 16-bit colour framebuffer
     pub fn bitmap3(&mut self) -> Bitmap3 {
         unsafe { Bitmap3::new() }
@@ -15,6 +25,6 @@ impl Video {
     }
 
     pub fn tiled0(&mut self) -> Tiled0 {
-        unsafe { Tiled0::new() }
+        unsafe { Tiled0::new(&self.blocks) }
     }
 }


### PR DESCRIPTION
Prevents double use of a map.
This aims to be the start of preventing the programmer from using tile memory for both tile and map data.