### PR TITLE
Better Backgrounds for large maps

### DIFF
--- a/agb/examples/chicken.rs
+++ b/agb/examples/chicken.rs
@@ -3,7 +3,7 @@
 
 extern crate agb;
 use agb::{
-    display::{object::ObjectStandard, tiled0, HEIGHT, WIDTH},
+    display::{object::ObjectStandard, HEIGHT, WIDTH},
     input::Button,
 };
 use core::convert::TryInto;

--- a/agb/examples/chicken.rs
+++ b/agb/examples/chicken.rs
@@ -51,19 +51,12 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
     gfx.set_sprite_palette(&CHICKEN_PALETTE);
     gfx.set_sprite_tilemap(&CHICKEN_TILES);
 
-    gfx.set_background_palette(&MAP_PALETTE);
-    gfx.set_background_tilemap(&MAP_TILES);
+    gfx.set_background_palette_raw(&MAP_PALETTE);
+    gfx.set_background_tilemap(0, &MAP_TILES);
 
-    gfx.background_0.enable();
-    gfx.background_0
-        .set_background_size(tiled0::BackgroundSize::S32x32);
-    gfx.background_0
-        .set_colour_mode(tiled0::ColourMode::FourBitPerPixel);
-
-    // This interface is not yet safe, as this can easily clobber the tiles.
-    // Not sure how to make this interface safe to use
-    gfx.background_0.set_screen_base_block(1);
-    gfx.copy_to_map(1, &MAP_MAP);
+    let mut background = gfx.get_background().unwrap();
+    background.set_map(&MAP_MAP, 32, 32);
+    background.show();
 
     let mut object = gfx.object;
 

--- a/agb/examples/test_logo.rs
+++ b/agb/examples/test_logo.rs
@@ -3,7 +3,7 @@
 
 extern crate agb;
 
-use agb::display::{example_logo, tiled0};
+use agb::display::example_logo;
 
 #[start]
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
@@ -11,31 +11,19 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
     let mut gfx = gba.display.video.tiled0();
 
     gfx.set_background_palettes(example_logo::PALETTE_DATA);
-    gfx.set_background_tilemap(example_logo::TILE_DATA);
+    gfx.set_background_tilemap(0, example_logo::TILE_DATA);
 
-    gfx.background_0.enable();
-    gfx.background_0
-        .set_background_size(tiled0::BackgroundSize::S32x32);
-    gfx.background_0
-        .set_colour_mode(tiled0::ColourMode::FourBitPerPixel);
+    let mut back = gfx.get_background().unwrap();
 
-    gfx.background_0.set_screen_base_block(20);
-
-    let mut entries: [u16; 32 * 20] = [0; 32 * 20];
-    for i in 0..(32 * 20) {
-        let x = i % 32;
-        let y = i / 32;
-
-        if x >= 30 {
-            continue;
-        }
-
-        let tile_id = (x + y * 30) as u16;
+    let mut entries: [u16; 30 * 20] = [0; 30 * 20];
+    for tile_id in 0..(30 * 20) {
         let palette_entry = example_logo::PALETTE_ASSIGNMENT[tile_id as usize] as u16;
-        entries[i] = tile_id | (palette_entry << 12);
+        entries[tile_id as usize] = tile_id | (palette_entry << 12);
     }
 
-    gfx.copy_to_map(20, &entries);
+    back.set_map(&entries, 30, 20);
+    back.set_position(0, 0);
+    back.show();
 
     loop {}
 }

--- a/agb/src/display/tiled0.rs
+++ b/agb/src/display/tiled0.rs
@@ -134,9 +134,7 @@ impl Background<'_> {
     fn map_get(&self, x: i32, y: i32, default: u16) -> u16 {
         let map = self.map.unwrap();
 
-        if x >= self.map_dim_x as i32 || x < 0 {
-            default
-        } else if y >= self.map_dim_y as i32 || y < 0 {
+        if x >= self.map_dim_x as i32 || x < 0 || y >= self.map_dim_y as i32 || y < 0 {
             default
         } else {
             map[(self.map_dim_x as i32 * y + x) as usize]

--- a/agb/src/display/tiled0.rs
+++ b/agb/src/display/tiled0.rs
@@ -19,13 +19,6 @@ const TILE_SPRITE: MemoryMapped1DArray<u32, { 512 * 8 }> =
 
 const MAP: *mut [[[u16; 32]; 32]; 32] = 0x0600_0000 as *mut _;
 
-pub enum BackgroundLayer {
-    Background0 = 0,
-    Background1 = 1,
-    Background2 = 2,
-    Background3 = 3,
-}
-
 pub enum Prioriry {
     P0 = 0,
     P1 = 1,

--- a/agb/src/display/tiled0.rs
+++ b/agb/src/display/tiled0.rs
@@ -266,6 +266,12 @@ impl Tiled0 {
         }
     }
 
+    pub fn set_background_palette_raw(&mut self, palette: &[u16]) {
+        for (index, &colour) in palette.iter().enumerate() {
+            PALETTE_BACKGROUND.set(index, colour);
+        }
+    }
+
     fn set_background_palette(&mut self, pal_index: u8, palette: &palette16::Palette16) {
         for (colour_index, &colour) in palette.colours.iter().enumerate() {
             PALETTE_BACKGROUND.set(pal_index as usize * 16 + colour_index, colour);

--- a/agb/src/display/tiled0.rs
+++ b/agb/src/display/tiled0.rs
@@ -349,7 +349,7 @@ impl Tiled0 {
         // round up rather than down
         let end_block = (start_tile * 8 + tiles.len() as u32 + u32_per_block - 1) / u32_per_block;
 
-        let blocks_to_use: u32 = (1 << (end_block - start_block)) - 1 << start_block;
+        let blocks_to_use: u32 = ((1 << (end_block - start_block)) - 1) << start_block;
 
         assert!(
             self.used_blocks & blocks_to_use == 0,

--- a/agb/src/display/tiled0.rs
+++ b/agb/src/display/tiled0.rs
@@ -46,25 +46,61 @@ pub enum BackgroundSize {
 }
 
 #[non_exhaustive]
-pub struct Background {
-    layer: usize,
+pub struct Background<'a> {
+    background: u8,
+    block: u8,
+    map: Option<&'a [u16]>,
+    map_dim_x: u32,
+    map_dim_y: u32,
+    pos_x: i32,
+    pos_y: i32,
 }
 
-impl Background {
-    pub fn enable(&mut self) {
+impl<'a> Background<'a> {
+    unsafe fn new(layer: u8, block: u8) -> Background<'a> {
+        let mut background = Background {
+            background: layer,
+            block,
+            map: None,
+            map_dim_x: 0,
+            map_dim_y: 0,
+            pos_x: 0,
+            pos_y: 0,
+        };
+        background.set_colour_mode(ColourMode::FourBitPerPixel);
+        background.set_background_size(BackgroundSize::S32x32);
+        background.set_block(block);
+        background
+    }
+
+    pub fn set_map(&mut self, map: &'a [u16], dim_x: u32, dim_y: u32) {
+        self.map = Some(map);
+        self.map_dim_x = dim_x;
+        self.map_dim_y = dim_y;
+        self.draw_full_map();
+    }
+}
+
+impl Background<'_> {
+    pub fn show(&mut self) {
+        assert!(self.map.is_some(), "map should be set before showing");
         let mode = DISPLAY_CONTROL.get();
-        let new_mode = mode | (1 << (self.layer + 0x08));
+        let new_mode = mode | (1 << (self.background + 0x08));
         DISPLAY_CONTROL.set(new_mode);
     }
 
-    pub fn disable(&mut self) {
+    pub fn hide(&mut self) {
         let mode = DISPLAY_CONTROL.get();
-        let new_mode = mode | !(1 << (self.layer + 0x08));
+        let new_mode = mode | !(1 << (self.background + 0x08));
         DISPLAY_CONTROL.set(new_mode);
     }
 
     unsafe fn get_register(&mut self) -> *mut u16 {
-        (0x0400_0008 + 2 * self.layer) as *mut u16
+        (0x0400_0008 + 2 * self.background as usize) as *mut u16
+    }
+
+    unsafe fn set_block(&mut self, block: u8) {
+        self.set_bits(0x08, 5, block as u16)
     }
 
     unsafe fn set_bits(&mut self, start: u16, num_bits: u16, bits: u16) {
@@ -79,29 +115,126 @@ impl Background {
         unsafe { self.set_bits(0, 2, p as u16) }
     }
 
-    pub fn set_colour_mode(&mut self, mode: ColourMode) {
+    fn set_colour_mode(&mut self, mode: ColourMode) {
         unsafe { self.set_bits(0x07, 1, mode as u16) }
     }
 
-    pub fn set_background_size(&mut self, size: BackgroundSize) {
+    fn set_background_size(&mut self, size: BackgroundSize) {
         unsafe { self.set_bits(0x0E, 2, size as u16) }
     }
 
-    pub fn set_screen_base_block(&mut self, block: u32) {
-        assert!(
-            block < 32,
-            "screen base block must be in range 0 to 31 inclusive"
-        );
-        unsafe { self.set_bits(0x08, 5, block as u16) }
+    fn map_get(&self, x: i32, y: i32, default: u16) -> u16 {
+        let map = self.map.unwrap();
+
+        if x >= self.map_dim_x as i32 || x < 0 {
+            default
+        } else if y >= self.map_dim_y as i32 || y < 0 {
+            default
+        } else {
+            map[(self.map_dim_x as i32 * y + x) as usize]
+        }
+    }
+
+    fn set_x(&mut self, x: u16) {
+        unsafe { *((0x0400_0010 + 4 * self.background as usize) as *mut u16) = x }
+    }
+    fn set_y(&mut self, y: u16) {
+        unsafe { *((0x0400_0012 + 4 * self.background as usize) as *mut u16) = y }
+    }
+
+    pub fn draw_full_map(&mut self) {
+        let x_map_space = self.pos_x / 8;
+        let y_map_space = self.pos_y / 8;
+
+        let x_block_space = x_map_space % 32;
+        let y_block_space = y_map_space % 32;
+
+        for x in -1..31 {
+            for y in -1..21 {
+                unsafe {
+                    (&mut (*MAP)[self.block as usize][(y_block_space + y).rem_euclid(32) as usize]
+                        [(x_block_space + x).rem_euclid(32) as usize]
+                        as *mut u16)
+                        .write_volatile(self.map_get(x_map_space + x, y_map_space + y, 0))
+                };
+            }
+        }
+    }
+
+    pub fn set_position(&mut self, x: i32, y: i32) {
+        let x_map_space = x / 8;
+        let y_map_space = y / 8;
+
+        let prev_x_map_space = self.pos_x / 8;
+        let prev_y_map_space = self.pos_y / 8;
+
+        let x_difference = x_map_space - prev_x_map_space;
+        let y_difference = y_map_space - prev_y_map_space;
+
+        let x_block_space = x_map_space % 32;
+        let y_block_space = y_map_space % 32;
+
+        self.pos_x = x;
+        self.pos_y = y;
+
+        // don't fancily handle if we've moved more than one tile, just copy the whole new map
+        if x_difference.abs() > 1 || y_difference.abs() > 1 {
+            self.draw_full_map();
+        } else {
+            if x_difference != 0 {
+                let x_offset = match x_difference {
+                    -1 => -1,
+                    1 => 30,
+                    _ => unreachable!(),
+                };
+                for y in -1..21 {
+                    unsafe {
+                        (&mut (*MAP)[self.block as usize]
+                            [(y_block_space + y).rem_euclid(32) as usize]
+                            [(x_block_space + x_offset).rem_euclid(32) as usize]
+                            as *mut u16)
+                            .write_volatile(self.map_get(
+                                x_map_space + x_offset,
+                                y_map_space + y,
+                                0,
+                            ))
+                    };
+                }
+            }
+            if y_difference != 0 {
+                let y_offset = match y_difference {
+                    -1 => -1,
+                    1 => 20,
+                    _ => unreachable!(),
+                };
+                for x in -1..31 {
+                    unsafe {
+                        (&mut (*MAP)[self.block as usize]
+                            [(y_block_space + y_offset).rem_euclid(32) as usize]
+                            [(x_block_space + x).rem_euclid(32) as usize]
+                            as *mut u16)
+                            .write_volatile(self.map_get(
+                                x_map_space + x,
+                                y_map_space + y_offset,
+                                0,
+                            ))
+                    };
+                }
+            }
+        }
+
+        let x_remainder = x % (32 * 8);
+        let y_remainder = y % (32 * 8);
+
+        self.set_x(x_remainder as u16);
+        self.set_y(y_remainder as u16);
     }
 }
 
 #[non_exhaustive]
 pub struct Tiled0 {
-    pub background_0: Background,
-    pub background_1: Background,
-    pub background_2: Background,
-    pub background_3: Background,
+    used_blocks: u32,
+    num_backgrounds: u8,
     pub object: ObjectControl,
 }
 
@@ -110,25 +243,20 @@ impl Tiled0 {
         set_graphics_settings(GraphicsSettings::empty());
         set_graphics_mode(DisplayMode::Tiled0);
         Tiled0 {
-            background_0: Background { layer: 0 },
-            background_1: Background { layer: 1 },
-            background_2: Background { layer: 2 },
-            background_3: Background { layer: 3 },
+            used_blocks: 0,
+            num_backgrounds: 0,
             object: ObjectControl::new(),
         }
     }
 
-    pub fn set_sprite_palette_entry(&mut self, index: u8, colour: u16) {
+    fn set_sprite_palette_entry(&mut self, index: u8, colour: u16) {
         PALETTE_SPRITE.set(index as usize, colour)
     }
-    pub fn set_background_palette_entry(&mut self, index: u8, colour: u16) {
-        PALETTE_BACKGROUND.set(index as usize, colour)
-    }
-    pub fn set_sprite_tilemap_entry(&mut self, index: u32, data: u32) {
+    fn set_sprite_tilemap_entry(&mut self, index: u32, data: u32) {
         TILE_SPRITE.set(index as usize, data);
     }
 
-    pub fn set_background_tilemap_entry(&mut self, index: u32, data: u32) {
+    fn set_background_tilemap_entry(&mut self, index: u32, data: u32) {
         TILE_BACKGROUND.set(index as usize, data);
     }
 
@@ -138,20 +266,15 @@ impl Tiled0 {
         }
     }
 
-    pub fn set_background_palette(&mut self, colour: &[u16]) {
-        for (index, &entry) in colour.iter().enumerate() {
-            self.set_background_palette_entry(index.try_into().unwrap(), entry)
+    fn set_background_palette(&mut self, pal_index: u8, palette: &palette16::Palette16) {
+        for (colour_index, &colour) in palette.colours.iter().enumerate() {
+            PALETTE_BACKGROUND.set(pal_index as usize * 16 + colour_index, colour);
         }
     }
 
     pub fn set_background_palettes(&mut self, palettes: &[palette16::Palette16]) {
         for (palette_index, entry) in palettes.iter().enumerate() {
-            for (colour_index, &colour) in entry.colours.iter().enumerate() {
-                self.set_background_palette_entry(
-                    (palette_index * 16 + colour_index) as u8,
-                    colour,
-                );
-            }
+            self.set_background_palette(palette_index as u8, entry)
         }
     }
 
@@ -161,17 +284,56 @@ impl Tiled0 {
         }
     }
 
-    pub fn set_background_tilemap(&mut self, tiles: &[u32]) {
-        for (index, &tile) in tiles.iter().enumerate() {
-            self.set_background_tilemap_entry(index as u32, tile)
+    pub fn get_background(&mut self) -> Result<Background, &'static str> {
+        if self.num_backgrounds >= 4 {
+            return Err("too many backgrounds created, maximum is 4");
         }
+
+        if !self.used_blocks == 0 {
+            return Err("all blocks are used");
+        }
+
+        let mut availiable_block = u8::MAX;
+
+        for i in 0..32 {
+            if (1 << i) & self.used_blocks == 0 {
+                availiable_block = i;
+                break;
+            }
+        }
+
+        assert!(
+            availiable_block != u8::MAX,
+            "should be able to find a block"
+        );
+
+        self.used_blocks |= 1 << availiable_block;
+
+        let background = self.num_backgrounds;
+        self.num_backgrounds = background + 1;
+        Ok(unsafe { Background::new(background, availiable_block) })
     }
 
-    pub fn copy_to_map(&mut self, map_id: usize, entries: &[u16]) {
-        let map =
-            unsafe { &mut ((*(MAP as *mut [[u16; 32 * 32]; 32]))[map_id]) as *mut [u16; 32 * 32] };
-        for (index, &entry) in entries.iter().enumerate() {
-            unsafe { (&mut (*map)[index] as *mut u16).write_volatile(entry) }
+    pub fn set_background_tilemap(&mut self, start_tile: u32, tiles: &[u32]) {
+        let u32_per_block = 512;
+
+        let start_block = (start_tile * 8) / u32_per_block;
+        // round up rather than down
+        let end_block = (start_tile * 8 + tiles.len() as u32 + u32_per_block - 1) / u32_per_block;
+
+        let blocks_to_use: u32 = (1 << (end_block - start_block)) - 1 << start_block;
+
+        assert!(
+            self.used_blocks & blocks_to_use == 0,
+            "blocks {} to {} should be unused for this copy to succeed",
+            start_block,
+            end_block
+        );
+
+        self.used_blocks |= blocks_to_use;
+
+        for (index, &tile) in tiles.iter().enumerate() {
+            self.set_background_tilemap_entry(start_tile + index as u32, tile)
         }
     }
 }


### PR DESCRIPTION
Handy way of handling maps for games. Automatically handles copying correct portion of map and the horizontal and vertical offset registers.

Also fixes relevant examples.

No example is provided with this funtionality showing.