### PR TITLE
gdb-debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 target
 /out
-/.vscode

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "type": "gdb",
             "request": "attach",
             "name": "Attach to gdbserver",
-            "executable": "target/thumbv4t-none-eabi/debug/examples/chicken",
+            "executable": "agb/target/thumbv4t-none-eabi/debug/examples/chicken",
             "target": "127.0.0.1:2345",
             "remote": true,
             "cwd": "${workspaceRoot}",

--- a/agb/.vscode/launch.json
+++ b/agb/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "gdb",
+            "request": "attach",
+            "name": "Attach to gdbserver",
+            "executable": "target/thumbv4t-none-eabi/debug/examples/chicken",
+            "target": "127.0.0.1:2345",
+            "remote": true,
+            "cwd": "${workspaceRoot}",
+            "gdbpath": "arm-none-eabi-gdb",
+        }
+    ]
+}

--- a/agb/Cargo.toml
+++ b/agb/Cargo.toml
@@ -7,7 +7,8 @@ description = "Library for Game Boy Advance Development"
 license = "MPL-2.0"
 
 [profile.dev]
-opt-level = 2
+opt-level = 0
+debug = true
 
 [profile.release]
 panic = "abort"

--- a/agb/build.rs
+++ b/agb/build.rs
@@ -12,6 +12,7 @@ fn main() {
     let out = std::process::Command::new("arm-none-eabi-as")
         .arg("-mthumb-interwork")
         .arg("-mthumb")
+        .arg("-g")
         .args(&["-o", out_file_path.as_str()])
         .arg("crt0.s")
         .output()

--- a/agb/gba.ld
+++ b/agb/gba.ld
@@ -69,6 +69,38 @@ SECTIONS {
     __ewram_rom_length_bytes = __ewram_data_end - __ewram_data_start;
     __ewram_rom_length_halfwords = (__ewram_rom_length_bytes + 1) / 2;
 
+        /* debugging sections */
+    /* Stabs */
+    .stab            0 : { *(.stab) }
+    .stabstr         0 : { *(.stabstr) }
+    .stab.excl       0 : { *(.stab.excl) }
+    .stab.exclstr    0 : { *(.stab.exclstr) }
+    .stab.index      0 : { *(.stab.index) }
+    .stab.indexstr   0 : { *(.stab.indexstr) }
+    .comment         0 : { *(.comment) }
+    /* DWARF 1 */
+    .debug           0 : { *(.debug) }
+    .line            0 : { *(.line) }
+    /* GNU DWARF 1 extensions */
+    .debug_srcinfo   0 : { *(.debug_srcinfo) }
+    .debug_sfnames   0 : { *(.debug_sfnames) }
+    /* DWARF 1.1 and DWARF 2 */
+    .debug_aranges   0 : { *(.debug_aranges) }
+    .debug_pubnames  0 : { *(.debug_pubnames) }
+    /* DWARF 2 */
+    .debug_info      0 : { *(.debug_info) }
+    .debug_abbrev    0 : { *(.debug_abbrev) }
+    .debug_line      0 : { *(.debug_line) }
+   	.debug_frame     0 : { *(.debug_frame) }
+    .debug_str       0 : { *(.debug_str) }
+    .debug_loc       0 : { *(.debug_loc) }
+    .debug_macinfo   0 : { *(.debug_macinfo) }
+    /* SGI/MIPS DWARF 2 extensions */
+    .debug_weaknames 0 : { *(.debug_weaknames) }
+    .debug_funcnames 0 : { *(.debug_funcnames) }
+    .debug_typenames 0 : { *(.debug_typenames) }
+    .debug_varnames  0 : { *(.debug_varnames) }
+
     /* discard anything not already mentioned */
     /DISCARD/ : { *(*) }
 }


### PR DESCRIPTION
Adds gdb debugging support.
You may require multiarch gdb or arm-none-eabi-gdb, probably provided with your package manager.

Arch: arm-none-eabi-gdb
Ubuntu: gdb-multiarch

Although untested on Ubuntu.

Furthermore, the launch.json requires the 'Native Debug' extension in vscode.