### PR TITLE
add rust-toolchain.toml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,13 +22,6 @@ jobs:
        sudo apt-get install libzip5 ./mGBA-0.9.0-ubuntu64-focal/libmgba.deb -y && \
        rm -rf mgba.tar.xz mGBA-0.9.0-ubuntu64-focal
     - uses: actions/checkout@v2
-    - name: Nightly rust with required components
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly-2021-04-20
-        components: clippy, rust-src
-        override: true
-
     - name: Cache
       uses: actions/cache@v2.1.1
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           agb/target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ steps.rust_install.outputs.rustc_hash }}
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: install mgba-test-runner
       run: cargo install --path mgba-test-runner

--- a/agb/rust-toolchain.toml
+++ b/agb/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = ["rust-src"]

--- a/agb/rust-toolchain.toml
+++ b/agb/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly"
-components = ["rust-src"]
+components = ["rust-src", "clippy"]


### PR DESCRIPTION
This should mean that user no longer needs to change default channel to build iff rustup is installed.

Also removes rust install step from action, because hopefully this will also work by default.