### PR TITLE
Improve fixnum

### DIFF
--- a/agb/src/number.rs
+++ b/agb/src/number.rs
@@ -27,7 +27,7 @@ where
     T: Into<Num<N>>,
 {
     fn add_assign(&mut self, rhs: T) {
-        self.0 += (*self + rhs.into()).0
+        self.0 = (*self + rhs.into()).0
     }
 }
 

--- a/agb/src/number.rs
+++ b/agb/src/number.rs
@@ -41,42 +41,26 @@ impl<const N: usize> SubAssign for Num<N> {
 impl<const N: usize> Mul for Num<N> {
     type Output = Self;
     fn mul(self, rhs: Num<N>) -> Self::Output {
-        if N % 2 == 0 {
-            Num((self.0 >> (N / 2)) * (rhs.0 >> (N / 2)))
-        } else {
-            Num((self.0 >> (1 + N / 2)) * (rhs.0 >> (N / 2)))
-        }
+        Num((self.0 * rhs.0) >> N)
     }
 }
 
 impl<const N: usize> MulAssign for Num<N> {
     fn mul_assign(&mut self, rhs: Self) {
-        if N % 2 == 0 {
-            self.0 = (self.0 >> (N / 2)) * (rhs.0 >> (N / 2))
-        } else {
-            self.0 = (self.0 >> (1 + N / 2)) * (rhs.0 >> (N / 2))
-        }
+        self.0 = (*self * rhs).0
     }
 }
 
 impl<const N: usize> Div for Num<N> {
     type Output = Self;
     fn div(self, rhs: Num<N>) -> Self::Output {
-        if N % 2 == 0 {
-            Num((self.0 << (N / 2)) / (rhs.0 >> (N / 2)))
-        } else {
-            Num((self.0 << (1 + N / 2)) / (rhs.0 >> (N / 2)))
-        }
+        Num((self.0 << N) / rhs.0)
     }
 }
 
 impl<const N: usize> DivAssign for Num<N> {
     fn div_assign(&mut self, rhs: Self) {
-        if N % 2 == 0 {
-            self.0 = (self.0 << (N / 2)) / (rhs.0 >> (N / 2))
-        } else {
-            self.0 = (self.0 << (1 + N / 2)) / (rhs.0 >> (N / 2))
-        }
+        self.0 = (*self / rhs).0
     }
 }
 

--- a/agb/src/number.rs
+++ b/agb/src/number.rs
@@ -12,55 +12,79 @@ impl<const N: usize> From<i32> for Num<N> {
     }
 }
 
-impl<const N: usize> Add for Num<N> {
+impl<T, const N: usize> Add<T> for Num<N>
+where
+    T: Into<Num<N>>,
+{
     type Output = Self;
-    fn add(self, rhs: Num<N>) -> Self::Output {
-        Num(self.0 + rhs.0)
+    fn add(self, rhs: T) -> Self::Output {
+        Num(self.0 + rhs.into().0)
     }
 }
 
-impl<const N: usize> AddAssign for Num<N> {
-    fn add_assign(&mut self, rhs: Self) {
-        self.0 += rhs.0
+impl<T, const N: usize> AddAssign<T> for Num<N>
+where
+    T: Into<Num<N>>,
+{
+    fn add_assign(&mut self, rhs: T) {
+        self.0 += (*self + rhs.into()).0
     }
 }
 
-impl<const N: usize> Sub for Num<N> {
+impl<T, const N: usize> Sub<T> for Num<N>
+where
+    T: Into<Num<N>>,
+{
     type Output = Self;
-    fn sub(self, rhs: Num<N>) -> Self::Output {
-        Num(self.0 - rhs.0)
+    fn sub(self, rhs: T) -> Self::Output {
+        Num(self.0 - rhs.into().0)
     }
 }
 
-impl<const N: usize> SubAssign for Num<N> {
-    fn sub_assign(&mut self, rhs: Self) {
-        self.0 -= rhs.0
+impl<T, const N: usize> SubAssign<T> for Num<N>
+where
+    T: Into<Num<N>>,
+{
+    fn sub_assign(&mut self, rhs: T) {
+        self.0 = (*self - rhs.into()).0
     }
 }
 
-impl<const N: usize> Mul for Num<N> {
+impl<T, const N: usize> Mul<T> for Num<N>
+where
+    T: Into<Num<N>>,
+{
     type Output = Self;
-    fn mul(self, rhs: Num<N>) -> Self::Output {
-        Num((self.0 * rhs.0) >> N)
+    fn mul(self, rhs: T) -> Self::Output {
+        Num((self.0 * rhs.into().0) >> N)
     }
 }
 
-impl<const N: usize> MulAssign for Num<N> {
-    fn mul_assign(&mut self, rhs: Self) {
-        self.0 = (*self * rhs).0
+impl<T, const N: usize> MulAssign<T> for Num<N>
+where
+    T: Into<Num<N>>,
+{
+    fn mul_assign(&mut self, rhs: T) {
+        self.0 = (*self * rhs.into()).0
     }
 }
 
-impl<const N: usize> Div for Num<N> {
+impl<T, const N: usize> Div<T> for Num<N>
+where
+    T: Into<Num<N>>,
+{
     type Output = Self;
-    fn div(self, rhs: Num<N>) -> Self::Output {
-        Num((self.0 << N) / rhs.0)
+    fn div(self, rhs: T) -> Self::Output {
+        Num((self.0 << N) / rhs.into().0)
     }
 }
 
-impl<const N: usize> DivAssign for Num<N> {
-    fn div_assign(&mut self, rhs: Self) {
-        self.0 = (*self / rhs).0
+impl<T, const N: usize> DivAssign<T> for Num<N>
+where
+    T: Into<Num<N>>,
+{
+    fn div_assign(&mut self, rhs: T) {
+        self.0 = (*self / rhs.into()).0
     }
 }
 
@@ -92,16 +116,16 @@ impl<const N: usize> Num<N> {
 fn test_numbers(_gba: &mut super::Gba) {
     // test addition
     let n: Num<8> = 1.into();
-    assert_eq!(n + 2.into(), 3.into(), "testing that 1 + 2 == 3");
+    assert_eq!(n + 2, 3.into(), "testing that 1 + 2 == 3");
 
     // test multiplication
     let n: Num<8> = 5.into();
-    assert_eq!(n * 3.into(), 15.into(), "testing that 5 * 3 == 15");
+    assert_eq!(n * 3, 15.into(), "testing that 5 * 3 == 15");
 
     // test division
     let n: Num<8> = 30.into();
     let p: Num<8> = 3.into();
-    assert_eq!(n / 20.into(), p / 2.into(), "testing that 30 / 20 == 3 / 2");
+    assert_eq!(n / 20, p / 2, "testing that 30 / 20 == 3 / 2");
 
     assert_ne!(n, p, "testing that 30 != 3");
 }

--- a/agb/src/number.rs
+++ b/agb/src/number.rs
@@ -106,6 +106,42 @@ fn test_numbers(_gba: &mut super::Gba) {
     assert_ne!(n, p, "testing that 30 != 3");
 }
 
+#[test_case]
+fn test_division_by_one(_gba: &mut super::Gba) {
+    let one: Num<8> = 1.into();
+
+    for i in -40..40 {
+        let n: Num<8> = i.into();
+        assert_eq!(n / one, n);
+    }
+}
+
+#[test_case]
+fn test_division_and_multiplication_by_16(_gba: &mut super::Gba) {
+    let sixteen: Num<8> = 16.into();
+
+    for i in -40..40 {
+        let n: Num<8> = i.into();
+        let m = n / sixteen;
+
+        assert_eq!(m * sixteen, n);
+    }
+}
+
+#[test_case]
+fn test_division_by_2_and_15(_gba: &mut super::Gba) {
+    let two: Num<8> = 2.into();
+    let fifteen: Num<8> = 15.into();
+    let thirty: Num<8> = 30.into();
+
+    for i in -128..128 {
+        let n: Num<8> = i.into();
+
+        assert_eq!(n / two / fifteen, n / thirty);
+        assert_eq!(n / fifteen / two, n / thirty);
+    }
+}
+
 impl<const N: usize> Display for Num<N> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let integral = self.0 >> N;


### PR DESCRIPTION
A few improvements:
1. Implements multiply and divide in a way that maximises precision
2. Implements the assign variants in terms of the non assign variants
3. Implements the traits against anything that implements Into<Num<N>> which allows us to write things like `one + 3` without needing the `.into()` everywhere :D