### PR TITLE
Allow agb image converter to be used in any crate

### DIFF
--- a/agb-image-converter/Cargo.lock
+++ b/agb-image-converter/Cargo.lock
@@ -19,6 +19,7 @@ name = "agb_image_converter"
 version = "0.1.0"
 dependencies = [
  "image",
+ "typed-builder",
 ]
 
 [[package]]
@@ -278,6 +279,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "rayon"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +334,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "syn"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tiff"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +354,23 @@ dependencies = [
  "miniz_oxide 0.4.4",
  "weezl",
 ]
+
+[[package]]
+name = "typed-builder"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345426c7406aa355b60c5007c79a2d1f5b605540072795222f17f6443e6a9c6f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "weezl"

--- a/agb-image-converter/Cargo.toml
+++ b/agb-image-converter/Cargo.toml
@@ -8,3 +8,4 @@ description = "Library for converting graphics for use on the Game Boy Advance"
 
 [dependencies]
 image = "0.23.14"
+typed-builder = "0.9.0"

--- a/agb-image-converter/src/lib.rs
+++ b/agb-image-converter/src/lib.rs
@@ -2,6 +2,8 @@ use std::fs::File;
 use std::io::BufWriter;
 use std::path::PathBuf;
 
+use typed_builder::TypedBuilder;
+
 mod colour;
 mod image_loader;
 mod palette16;
@@ -26,14 +28,16 @@ impl TileSize {
     }
 }
 
+#[derive(TypedBuilder)]
 pub struct ImageConverterConfig {
-    pub transparent_colour: Option<Colour>,
-    pub tile_size: TileSize,
-    pub input_image: PathBuf,
-    pub output_file: PathBuf,
+    #[builder(default, setter(strip_option))]
+    transparent_colour: Option<Colour>,
+    tile_size: TileSize,
+    input_image: PathBuf,
+    output_file: PathBuf,
 }
 
-pub fn convert_image(settings: &ImageConverterConfig) {
+pub fn convert_image(settings: ImageConverterConfig) {
     let image = Image::load_from_file(&settings.input_image);
 
     let tile_size = settings.tile_size.to_size();

--- a/agb-image-converter/src/lib.rs
+++ b/agb-image-converter/src/lib.rs
@@ -35,6 +35,9 @@ pub struct ImageConverterConfig {
     tile_size: TileSize,
     input_image: PathBuf,
     output_file: PathBuf,
+
+    #[builder(default, setter(strip_option))]
+    crate_prefix: Option<String>,
 }
 
 pub fn convert_image(settings: ImageConverterConfig) {
@@ -56,6 +59,7 @@ pub fn convert_image(settings: ImageConverterConfig) {
         &optimisation_results,
         &image,
         settings.tile_size,
+        settings.crate_prefix.unwrap_or("agb".to_owned()),
     )
     .expect("Failed to write data");
 }

--- a/agb-image-converter/src/rust_generator.rs
+++ b/agb-image-converter/src/rust_generator.rs
@@ -10,14 +10,20 @@ pub(crate) fn generate_code(
     results: &Palette16OptimisationResults,
     image: &Image,
     tile_size: TileSize,
+    crate_prefix: String,
 ) -> io::Result<()> {
     writeln!(
         output,
-        "pub const PALETTE_DATA: &[crate::display::palette16::Palette16] = &[",
+        "pub const PALETTE_DATA: &[{}::display::palette16::Palette16] = &[",
+        crate_prefix,
     )?;
 
     for palette in &results.optimised_palettes {
-        write!(output, "    crate::display::palette16::Palette16::new([")?;
+        write!(
+            output,
+            "    {}::display::palette16::Palette16::new([",
+            crate_prefix
+        )?;
 
         for colour in palette.clone() {
             write!(output, "0x{:08x}, ", colour.to_rgb15())?;


### PR DESCRIPTION
agb-image-converter defaults to `crate::foo` but outside the agb crate, that should be `agb::`.

Future PR will take advantage of this change in agb along with the refactor to using a builder rather than what we have at the moment.