### PR TITLE
Improve affine matrix syscall arguments

### DIFF
--- a/agb/src/syscall.rs
+++ b/agb/src/syscall.rs
@@ -145,7 +145,9 @@ pub fn affine_matrix(x_scale: Num<8>, y_scale: Num<8>, rotation: u8) -> AffineMa
 #[test_case]
 fn affine(_gba: &mut crate::Gba) {
     // expect identity matrix
-    let aff = affine_matrix(1 << 8, 1 << 8, 0);
-    assert_eq!(aff.p_a, 1 << 8);
-    assert_eq!(aff.p_d, 1 << 8);
+    let one: Num<8> = 1.into();
+
+    let aff = affine_matrix(one, one, 0);
+    assert_eq!(aff.p_a, one.to_raw() as i16);
+    assert_eq!(aff.p_d, one.to_raw() as i16);
 }

--- a/agb/src/syscall.rs
+++ b/agb/src/syscall.rs
@@ -1,4 +1,5 @@
 use crate::display::object::AffineMatrixAttributes;
+use crate::number::Num;
 
 #[allow(non_snake_case)]
 
@@ -105,7 +106,7 @@ pub fn arc_tan2(x: i16, y: i32) -> i16 {
     result
 }
 
-pub fn affine_matrix(x_scale: i16, y_scale: i16, rotation: u16) -> AffineMatrixAttributes {
+pub fn affine_matrix(x_scale: Num<8>, y_scale: Num<8>, rotation: u8) -> AffineMatrixAttributes {
     let mut result = AffineMatrixAttributes {
         p_a: 0,
         p_b: 0,
@@ -120,10 +121,12 @@ pub fn affine_matrix(x_scale: i16, y_scale: i16, rotation: u16) -> AffineMatrixA
         rotation: u16,
     }
 
+    let rotation_for_input = (rotation as u16) << 8;
+
     let input = Input {
-        x_scale,
-        y_scale,
-        rotation,
+        y_scale: x_scale.to_raw() as i16,
+        x_scale: y_scale.to_raw() as i16,
+        rotation: rotation_for_input,
     };
 
     unsafe {

--- a/agb/src/syscall.rs
+++ b/agb/src/syscall.rs
@@ -115,6 +115,7 @@ pub fn affine_matrix(x_scale: Num<8>, y_scale: Num<8>, rotation: u8) -> AffineMa
     };
 
     #[allow(dead_code)]
+    #[repr(C, packed)]
     struct Input {
         x_scale: i16,
         y_scale: i16,


### PR DESCRIPTION
Makes it a little more obvious what arguments the affine matrix syscall accepts.

Also fix a potential issue where the input struct wasn't correctly packed so could randomly break due to non-fixed ordering of the fields