### PR TITLE
Make it so that multiplication doesn't overflow so easily

### DIFF
--- a/agb/src/number.rs
+++ b/agb/src/number.rs
@@ -140,7 +140,11 @@ where
 {
     type Output = Self;
     fn mul(self, rhs: T) -> Self::Output {
-        Num((self.0 * rhs.into().0) >> N)
+        let rhs: Self = rhs.into();
+
+        Num(((self.floor() * rhs.floor()) << N)
+            + (self.floor() * rhs.frac() + rhs.floor() * self.frac())
+            + ((self.frac() * rhs.frac()) >> N))
     }
 }
 
@@ -238,6 +242,10 @@ impl<I: FixedWidthUnsignedInteger, const N: usize> Num<I, N> {
 
     pub fn floor(&self) -> I {
         self.0 >> N
+    }
+
+    pub fn frac(&self) -> I {
+        self.0 & ((I::one() << N) - I::one())
     }
 
     pub fn new(integral: I) -> Self {


### PR DESCRIPTION
Multiplication overflowed super easily (Number<8> could only multiply up to 255 * 255, Number<10> only up to 31 * 31) which is far from ideal. This pushes that ability to `2^((width - N) / 2)`.

The formula is just (a + b)(c + d) = ac + ad + bc + bd. This makes multiplications much more intensive, but hopefully doesn't matter too much (a divide is still 100 times worse :P)