### PR TITLE
Add sound priorities

### DIFF
--- a/agb/src/sound/mixer/mod.rs
+++ b/agb/src/sound/mixer/mod.rs
@@ -18,6 +18,12 @@ impl MixerController {
     }
 }
 
+#[derive(PartialEq, Eq)]
+enum SoundPriority {
+    High,
+    Low,
+}
+
 pub struct SoundChannel {
     data: &'static [u8],
     pos: Num<usize, 8>,
@@ -27,6 +33,8 @@ pub struct SoundChannel {
 
     panning: Num<i16, 4>, // between -1 and 1
     is_done: bool,
+
+    priority: SoundPriority,
 }
 
 impl SoundChannel {
@@ -38,6 +46,7 @@ impl SoundChannel {
             playback_speed: 1.into(),
             panning: 0.into(),
             is_done: false,
+            priority: SoundPriority::Low,
         }
     }
 
@@ -56,6 +65,11 @@ impl SoundChannel {
         debug_assert!(panning <= Num::new(1), "panning value must be <= 1");
 
         self.panning = panning;
+        self
+    }
+
+    pub fn high_priority(mut self) -> Self {
+        self.priority = SoundPriority::High;
         self
     }
 }

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -1,6 +1,6 @@
 use super::hw;
 use super::hw::LeftOrRight;
-use super::SoundChannel;
+use super::{SoundChannel, SoundPriority};
 use crate::number::Num;
 
 pub struct Mixer {
@@ -35,6 +35,19 @@ impl Mixer {
                 if !some_channel.is_done {
                     continue;
                 }
+            }
+
+            channel.replace(new_channel);
+            return;
+        }
+
+        if new_channel.priority == SoundPriority::Low {
+            return; // don't bother even playing it
+        }
+
+        for channel in self.channels.iter_mut() {
+            if channel.as_ref().unwrap().priority == SoundPriority::High {
+                continue;
             }
 
             channel.replace(new_channel);


### PR DESCRIPTION
Lets you play multiple sounds at once by declaring a channel as 'high' priority. A high priority channel will never be overwritten and will overwrite a low priority one if we run out of the 16 available channels.